### PR TITLE
fix: improve description validation and update dependencies

### DIFF
--- a/packages/publisher/index.ts
+++ b/packages/publisher/index.ts
@@ -18,14 +18,8 @@ const intoApplicationType = (type: number) =>
     type === 3 ? 1 : Math.log2(type);
 
 const makeDescription = (type: number, desc: string) => {
-  if ((type == CommandType.Slash || type == CommandType.Both) && (!desc || desc.length === 0)) {
+  if ((type == CommandType.Slash || type == CommandType.Both) && !desc) {
     throw new Error('Found application command that has no description field or is empty.');
-  }
-  if ((type == CommandType.CtxMsg || type == CommandType.CtxUser) && desc.length > 0) {
-    console.warn(
-      'Found context menu that has non empty description field. Implictly publishing with empty description.'
-    );
-    return '';
   }
   return desc;
 };
@@ -88,8 +82,8 @@ export class Publisher implements Init {
                                         contexts } = publish;
                                 return {
                                     name: module.name, type: applicationType,
-                                    //@ts-ignore we know description is at least empty str or filled
-                                    description: makeDescription(applicationType, module.description),
+                                    //DO NOT IGNORE! 
+                                    description:(module.type == CommandType.CtxMsg || module.type == CommandType.CtxUser) ? '' : makeDescription(applicationType, module.description),
                                     //@ts-ignore shutup
                                     options: optionsTransformer(module?.options),
                                     default_member_permissions,

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sern/publisher",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Publish commands in sern with ease!",
   "main": "dist/index.js",
   "scripts": {
@@ -9,8 +9,8 @@
     "test": "exit 0"
   },
   "devDependencies": {
-    "@sern/handler": "^4.0.0",
-    "discord.js": "^14.15.3",
+    "@sern/handler": "^4.2.4",
+    "discord.js": "^14.21.0",
     "vitest": "^1.2.2"
   },
   "keywords": [],


### PR DESCRIPTION
These changes explicitly removed description from the Context Commands. Originally, users could input a description field into Context commands, and it would "explicitly remove the description" from the command. As of discord.js version 14.21, the publisher would hiccup and still publish `description: '...'` to context commands. I had to bump the discord.js version to latest in the publisher before it would accept the change. 
version 14.15.x would show I was pushing description as empty string but discord still saw `description: '...'`
changed version to 14.21.0 and it pushed an empty string as expected...